### PR TITLE
Fixed exception when successfully invited

### DIFF
--- a/Services/Mailman.php
+++ b/Services/Mailman.php
@@ -417,7 +417,7 @@ class Services_Mailman
             return false;
         }
         if ($h5->item(0)->nodeValue) {
-            if ($h5->item(0)->nodeValue == 'Successfully subscribed:') {
+            if ($h5->item(0)->nodeValue == 'Successfully subscribed:' || $h5->item(0)->nodeValue == 'Successfully invited:') {
                 return $this;
             } else {
                 throw new Services_Mailman_Exception(


### PR DESCRIPTION
Fixed a problem where ->subscribe() with invite mode (requiring email confirmation) always throw exception. 

Currently, ->subscribe() only test for 'Successfully subscribed:' but not 'Successfully invited:'